### PR TITLE
Removed Speech marks on animation names to fix compatibility with IE.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html manifest="getoverhere.appcache">
 <head>
     <title>Get Over Here</title>
@@ -70,31 +71,31 @@ body.flash{
 
 }
 
-@-o-keyframes 'flash'{
+@-o-keyframes flash{
   0% { background: #2ecc71; }
   50% { background: none }
   100% { background: #2ecc71; }
 }
 
-@-ms-keyframes 'flash'{
+@-ms-keyframes flash{
   0% { background: #2ecc71; }
   50% { background: none }
   100% { background: #2ecc71; }
 }
 
-@-moz-keyframes 'flash'{
+@-moz-keyframes flash{
   0% { background: #2ecc71; }
   50% { background: none }
   100% { background: #2ecc71; }
 }
 
-@-webkit-keyframes 'flash'{
+@-webkit-keyframes flash{
   0% { background: #2ecc71; }
   50% { background: none }
   100% { background: #2ecc71; }
 }
 
-@keyframes 'flash'{
+@keyframes flash{
   0% { background: #2ecc71; }
   50% { background: none }
   100% { background: #2ecc71; }


### PR DESCRIPTION
Seems that IE doesn't like it if animation names are in speech marks.
